### PR TITLE
Drop `bld.bat`

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,2 +1,0 @@
-"%PYTHON%" setup.py install
-if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: 6de7371e7e8bd9e2dad3fef2646f4a43
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py3k]
   script: python setup.py install
 


### PR DESCRIPTION
The `bld.bat` file is no longer needed as `conda-build` will handle `script` on Windows.
